### PR TITLE
point setup.cfg to python3 version of zmq and hostlist

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,3 +1,3 @@
 [bdist_rpm]
 release = 1
-requires = python-hostlist python-zmq
+requires = python3-hostlist python3-zmq


### PR DESCRIPTION
setup.cfg is requiring python2 versions of zmq and hostlist. These need to be updated with python3 versions.